### PR TITLE
Add context action to manage file stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The extension provides these commands:
 3. **FilePrompt: Remove current file from ignore list** - Remove the currently open file from the ignore list
 4. **FilePrompt: Show history** - View your last 20 copy operations and save/manage file selection stacks
 5. **FilePrompt: Copy from saved stack** - Quick access to your saved file selection stacks
+6. **FilePrompt: Add selection to stack** - Add the currently selected explorer items to a named stack
 
 To use the "FilePrompt: Add current file to ignore list" command:
 - Open any file in VS Code/Cursor

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ],
     "main": "./extension.js",
     "activationEvents": [
-        "onCommand:filePrompt.copy"
+        "onCommand:filePrompt.copy",
+        "onCommand:filePrompt.addToStack"
     ],
     "contributes": {
         "commands": [
@@ -56,12 +57,20 @@
             {
                 "command": "filePrompt.copySavedStack",
                 "title": "FilePrompt: Saved Stacks"
+            },
+            {
+                "command": "filePrompt.addToStack",
+                "title": "FilePrompt: Add to Stack"
             }
         ],
         "menus": {
             "explorer/context": [
                 {
                     "command": "filePrompt.copy",
+                    "group": "navigation"
+                },
+                {
+                    "command": "filePrompt.addToStack",
                     "group": "navigation"
                 }
             ]


### PR DESCRIPTION
## Summary
- add a new `Add to Stack` command and explorer context menu item
- register new command in `package.json`
- document the command in README

## Testing
- `node --check extension.js`
- `npm install`
- `npm run package`


------
https://chatgpt.com/codex/tasks/task_e_6851ccbbc348832d9d00b2c2cce8ba19